### PR TITLE
+ minor tweak for output

### DIFF
--- a/tasks/csslint.js
+++ b/tasks/csslint.js
@@ -44,7 +44,7 @@ module.exports = function(grunt) {
     var hadErrors = 0;
     this.filesSrc.forEach(function( filepath ) {
       var file = grunt.file.read( filepath ),
-        message = "Linting " + filepath + "...",
+        message = "Linting " + filepath + " ...",
         result;
 
       // skip empty files


### PR DESCRIPTION
Inserted a whitespace to  appended '...' to make path copyable from cli.
Which gives us

```
$ Linting /path/to/file ...ERROR
instead of
$ Linting /path/to/file...ERROR
```
