### PR TITLE
Added the ability to force completion through options & hid stdout reporting if a reporter was present

### DIFF
--- a/tasks/csslint.js
+++ b/tasks/csslint.js
@@ -104,7 +104,7 @@ module.exports = function(grunt) {
       return false;
     }
     else if(force){
-      grunt.log.warn( this.filesSrc.length + grunt.util.pluralize(this.filesSrc.length, " file/ files") + "linted with " + hadErrors + " files containing errors.");
+      grunt.log.warn( this.filesSrc.length + grunt.util.pluralize(this.filesSrc.length, " file/ files") + " linted with " + hadErrors + " files containing errors.");
     }
     else{
       grunt.log.ok( this.filesSrc.length + grunt.util.pluralize(this.filesSrc.length, " file/ files") + " lint free." );


### PR DESCRIPTION
- Added the ability to force completion despite having errors through `options: { force: true }`. This was a problem if attempting to run the task directly because --force is not possible and `grunt.option('force', true)` was not working 
- Significantly reduced noise by moving the `grunt.log`s for warnings and errors into a conditional that only fires if another reporter is not present.
