### PR TITLE
Bump CSSLint to 0.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test": "grunt test --force"
   },
   "dependencies": {
-    "csslint": "~0.9.10"
+    "csslint": "~0.10.0"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "~0.2.0",


### PR DESCRIPTION
There was a slight delay, but the package just got published to NPM
