### PR TITLE
Allow CSSLint warnings to not fail the grunt test

### DIFF
--- a/tasks/csslint.js
+++ b/tasks/csslint.js
@@ -64,10 +64,10 @@ module.exports = function(grunt) {
         result.messages.forEach(function( message ) {
           grunt.log.writeln( "[".red + (typeof message.line !== "undefined" ? ( "L" + message.line ).yellow + ":".red + ( "C" + message.col ).yellow : "GENERAL".yellow) + "]".red );
           grunt.log[ message.type === "error" ? "error" : "writeln" ]( message.message + " " + message.rule.desc + " (" + message.rule.id + ")" );
+          if (message.type === "error") {
+            hadErrors += 1;
+          }
         });
-        if ( result.messages.length ) {
-          hadErrors += 1;
-        }
       } else {
         grunt.log.writeln( "Skipping empty file " + filepath);
       }


### PR DESCRIPTION
This changes the logic for checking if the task failed by only failing if the message.type === "error"
