### PR TITLE
Combines pull request #21 and #25 - Enables force, warnings do not stop build, and reporting to console is limited if another reporter is present

### DIFF
--- a/tasks/csslint.js
+++ b/tasks/csslint.js
@@ -66,7 +66,6 @@ module.exports = function(grunt) {
         combinedResult[filepath] = result;
 
         result.messages.forEach(function( message ) {
-          grunt.log[ message.type === "error" ? "error" : "writeln" ]( message.message + " " + message.rule.desc + " (" + message.rule.id + ")" );
           if (message.type === "error") {
             hadErrors += 1;
           }


### PR DESCRIPTION
- Merges pull #21, #25
- Providing `options: { force: true }` prevents csslint from returning false and thus stopping further tasks
- If another reporter is present, console logging is limited to summarization on a file level
- CssLint warnings are not constituted as errors so the task does not fail
