### PR TITLE
add wildcard disabled support

### DIFF
--- a/tasks/csslint.js
+++ b/tasks/csslint.js
@@ -31,8 +31,14 @@ module.exports = function(grunt) {
     // merge external options with options specified in gruntfile
     options = grunt.util._.extend( options, externalOptions );
 
+    // if we have disabled explicitly unspecified rules
+    var defaultDisabled = options['*'] === false;
+    delete options['*'];
+
     csslint.getRules().forEach(function( rule ) {
-      ruleset[ rule.id ] = 1;
+      if ( options[ rule.id ] || ! defaultDisabled ) {
+        ruleset[ rule.id ] = 1;
+      }
     });
 
     for ( var rule in options ) {


### PR DESCRIPTION
This allows a wildcard option to disable all unspecified rules by default. Useful for tasks that want to check only a few rules, without having to explicitly disable all other current and future rules.
