### PR TITLE
CSSLint warnings should not fail grunt test

### DIFF
--- a/tasks/csslint.js
+++ b/tasks/csslint.js
@@ -53,6 +53,7 @@ module.exports = function(grunt) {
     this.filesSrc.forEach(function( filepath ) {
       var file = grunt.file.read( filepath ),
         message = 'Linting ' + chalk.cyan(filepath) + '...',
+        failed = false,
         result;
 
       // skip empty files
@@ -61,7 +62,15 @@ module.exports = function(grunt) {
         verbose.write( message );
         if (result.messages.length) {
           verbose.or.write( message );
-          grunt.log.error();
+          failed = result.messages.reduce(function(failed, message){
+            return failed || message.type === "error";
+          }, failed);
+          if (failed) {
+            hadErrors += 1;
+            grunt.log.error();
+          } else {
+            grunt.log.writeln(chalk.yellow('WARNING'));
+          }
         } else {
           verbose.ok();
         }
@@ -83,9 +92,6 @@ module.exports = function(grunt) {
           grunt.log.writeln(chalk.red('[') + offenderMessage + chalk.red(']'));
           grunt.log[ message.type === 'error' ? 'error' : 'writeln' ]( message.message + ' ' + message.rule.desc + ' (' + message.rule.id + ')' );
         });
-        if ( result.messages.length ) {
-          hadErrors += 1;
-        }
       } else {
         grunt.log.writeln('Skipping empty file ' + chalk.cyan(filepath) + '.');
       }


### PR DESCRIPTION
This is a reintroduction of a modified version of pull request #25 which was replaced by #27 which was replaced by #31 and somewhere along the lines lost my change. 

This pull request adds detection for warnings coming out of csslint and not failing the build over them.
