### PR TITLE
Added option to load custom css lint rules

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -66,6 +66,15 @@ module.exports = function(grunt) {
           ]
         },
         src: 'test/fixtures/*.css'
+      },
+      withCustomRules: {
+        options: {
+          formatters: [
+            {id: 'csslint-xml', dest: 'tmp/csslintWithCustomRules.xml'}
+          ],
+          extraRules: 'test/extraRules/*.js'
+        },
+        src: 'test/fixtures/*.css'
       }
     },
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,12 @@ Default: `false`
 
 Only output errors.
 
+###### extraRules
+Type: `array|String`
+Default value: `null`
+
+Specifies the file paths/patterns containing extra csslint rules. The files need to be commonjs modules that export the csslint rule object which will be given to csslint.addRule(...)
+
 ### Usage Examples
 
 ```js

--- a/docs/csslint-options.md
+++ b/docs/csslint-options.md
@@ -99,3 +99,9 @@ Type: `boolean`
 Default: `false`
 
 Only output errors.
+
+###### extraRules
+Type: `array|String`
+Default value: `null`
+
+Specifies the file paths/patterns containing extra csslint rules. The files need to be commonjs modules that export the csslint rule object which will be given to csslint.addRule(...)

--- a/tasks/csslint.js
+++ b/tasks/csslint.js
@@ -22,6 +22,16 @@ module.exports = function(grunt) {
     var chalk = require('chalk');
     var absoluteFilePaths = options.absoluteFilePathsForFormatters || false;
 
+    if (options.extraRules) {
+      grunt.log.debug('Adding Extra CSSLint Rules', options.extraRules);
+      grunt.file.expand({}, options.extraRules).forEach(function(filepath) {
+        filepath = path.resolve(filepath);
+        grunt.log.debug('Adding Extra CSSLint Rule', filepath);
+        var rule = require(filepath);
+        csslint.addRule(rule);
+      });
+    }
+
     // Read CSSLint options from a specified csslintrc file.
     if (options.csslintrc) {
       var contents = grunt.file.read( options.csslintrc );

--- a/test/csslint_test.js
+++ b/test/csslint_test.js
@@ -54,5 +54,20 @@ exports.csslint = {
     test.equal(grunt.file.isPathAbsolute(path), false, 'should generate a relative file path.');
 
     test.done();
+  },
+  withCustomRules: function(test) {
+    // check if reports were generated
+    test.ok(grunt.file.isDir('tmp'), 'should create a folder "report".');
+    test.ok(grunt.file.exists('tmp/csslintWithCustomRules.xml'), 'should create a checkstyle report.');
+
+    // check if the file names in the reports are absolute
+    var checkstyleFile = grunt.file.read('tmp/csslintWithCustomRules.xml');
+    var path = checkstyleFile.substring(checkstyleFile.indexOf('file name="') + 'file name="'.length, checkstyleFile.indexOf('duplicate.css') + 'duplicate.css'.length);
+
+    test.ok(grunt.file.exists(path), 'should reference the right file.');
+    test.ok(grunt.file.isFile(path), 'should reference the right file.');
+    test.equal(grunt.file.isPathAbsolute(path), false, 'should generate a relative file path.');
+
+    test.done();
   }
 };

--- a/test/extraRules/duplicate-selector.js
+++ b/test/extraRules/duplicate-selector.js
@@ -1,0 +1,31 @@
+module.exports = {
+
+    //rule information
+    id: "duplicate-selector",
+    name: "Disallow duplicate selectors",
+    desc: "",
+    browsers: "All",
+
+    //initialization
+    init: function(parser, reporter) {
+        "use strict";
+        var rule = this;
+        var localSelectorMap = {}; // local styles
+
+        parser.addListener("startrule", function(event) {
+            var selectors = event.selectors,
+                selector,
+                text,
+                i;
+
+            for (i=0; i < selectors.length; i++) {
+                selector = selectors[i];
+                text = selector.text.replace(/[ ]+/g, ' ').trim();
+                if (localSelectorMap[text]) {
+                    reporter.report("Duplicate Selector Found: " + selector.text, selector.line, 1, rule);
+                }
+                localSelectorMap[text] = true;
+            }
+        });
+    }
+};

--- a/test/fixtures/duplicate.css
+++ b/test/fixtures/duplicate.css
@@ -1,0 +1,2 @@
+.slide { position: absolute; }
+.slide { top: 0; }


### PR DESCRIPTION
This pull request adds an "extraRules" option which takes a grunt file glob of css lint rules in the form of commonjs modules. These modules should export a csslint rule that you would normally provide to CSSLint.addRule(....).