### PR TITLE
Optional Limit displayed response types

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,12 @@ Default value: `false`
 
 If the absoluteFilePathsForFormatters option is specified and set to `true`, the file names in the generated reports are absolute.
 
+###### types 
+Type: `array`
+Default value: `[ 'error', 'warning', 'info' ]`
+
+Limit the types of responses.  Usefull for removing warnings and info in some circumstances.
+
 ### Usage Examples
 
 ```js

--- a/tasks/csslint.js
+++ b/tasks/csslint.js
@@ -20,7 +20,7 @@ module.exports = function(grunt) {
     var _ = require('lodash');
     var chalk = require('chalk');
     var absoluteFilePaths = options.absoluteFilePathsForFormatters || false;
-	var types = options.types || [ 'error', 'warning', 'info' ];
+    var types = options.types || [ 'error', 'warning', 'info' ];
 
     // Read CSSLint options from a specified csslintrc file.
     if (options.csslintrc) {

--- a/tasks/csslint.js
+++ b/tasks/csslint.js
@@ -20,6 +20,7 @@ module.exports = function(grunt) {
     var _ = require('lodash');
     var chalk = require('chalk');
     var absoluteFilePaths = options.absoluteFilePathsForFormatters || false;
+	var types = options.types || [ 'error', 'warning', 'info' ];
 
     // Read CSSLint options from a specified csslintrc file.
     if (options.csslintrc) {
@@ -59,6 +60,12 @@ module.exports = function(grunt) {
       if (file.length) {
         result = csslint.verify( file, ruleset );
         verbose.write( message );
+
+		// filter messages based on types we are looking for
+        result.messages = _.filter( result.messages, function( m ){
+          return _.contains( types , m.type.toLowerCase() );
+        });
+
         if (result.messages.length) {
           verbose.or.write( message );
           grunt.log.error();


### PR DESCRIPTION
Sometimes Warnings and Info can be non-useful information such as when you are not engaged in a CSS cleanup. This allows them to be hidden.