### PR TITLE
Allow comments in .csslintrc

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -57,6 +57,15 @@ module.exports = function(grunt) {
           ]
         },
         src: 'test/fixtures/*.css'
+      },
+      withComments: {
+        options: {
+          csslintrc: 'test/comments.csslintrc',
+          formatters: [
+            {id: 'csslint-xml', dest: 'tmp/csslintComments.xml'}
+          ]
+        },
+        src: 'test/fixtures/*.css'
       }
     },
 

--- a/package.json
+++ b/package.json
@@ -27,9 +27,10 @@
     "test": "grunt test --force"
   },
   "dependencies": {
-    "csslint": "~0.10.0",
     "chalk": "~0.5.1",
-    "lodash": "~2.4.1"
+    "csslint": "~0.10.0",
+    "lodash": "~2.4.1",
+    "strip-json-comments": "~1.0.2"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "~0.10.0",

--- a/tasks/csslint.js
+++ b/tasks/csslint.js
@@ -11,6 +11,7 @@
 module.exports = function(grunt) {
   grunt.registerMultiTask( 'csslint', 'Lint CSS files with csslint', function() {
     var csslint = require( 'csslint' ).CSSLint;
+    var stripJsonComments = require( 'strip-json-comments' );
     var ruleset = {};
     var verbose = grunt.verbose;
     var externalOptions = {};
@@ -23,7 +24,8 @@ module.exports = function(grunt) {
 
     // Read CSSLint options from a specified csslintrc file.
     if (options.csslintrc) {
-      externalOptions = grunt.file.readJSON( options.csslintrc );
+      var contents = grunt.file.read( options.csslintrc );
+      externalOptions = JSON.parse( stripJsonComments( contents ) );
       // delete csslintrc option to not confuse csslint if a future release
       // implements a rule or options on its own
       delete options.csslintrc;

--- a/test/comments.csslintrc
+++ b/test/comments.csslintrc
@@ -1,0 +1,10 @@
+{
+  /**
+   * block comment
+   */
+
+   // single-line comment
+
+   "import": 0, // inline comment
+   "ids": 0
+}

--- a/test/csslint_test.js
+++ b/test/csslint_test.js
@@ -4,7 +4,7 @@ var grunt = require('grunt');
 
 exports.csslint = {
   withReportsAbs: function(test) {
-    // check if reports where generated
+    // check if reports were generated
     test.ok(grunt.file.isDir('tmp'), 'should create a folder "report".');
     test.ok(grunt.file.exists('tmp/csslint.xml'), 'should create a checkstyle report.');
     test.ok(grunt.file.exists('tmp/csslint_junit.xml'), 'should create a junit report.');
@@ -26,12 +26,27 @@ exports.csslint = {
     test.done();
   },
   withReportsRel: function(test) {
-    // check if reports where generated
+    // check if reports were generated
     test.ok(grunt.file.isDir('tmp'), 'should create a folder "report".');
     test.ok(grunt.file.exists('tmp/csslintRel.xml'), 'should create a checkstyle report.');
 
     // check if the file names in the reports are absolute
     var checkstyleFile = grunt.file.read('tmp/csslintRel.xml');
+    var path = checkstyleFile.substring(checkstyleFile.indexOf('file name="') + 'file name="'.length, checkstyleFile.indexOf('invalid.css') + 'invalid.css'.length);
+
+    test.ok(grunt.file.exists(path), 'should reference the right file.');
+    test.ok(grunt.file.isFile(path), 'should reference the right file.');
+    test.equal(grunt.file.isPathAbsolute(path), false, 'should generate a relative file path.');
+
+    test.done();
+  },
+  withComments: function(test) {
+    // check if reports were generated
+    test.ok(grunt.file.isDir('tmp'), 'should create a folder "report".');
+    test.ok(grunt.file.exists('tmp/csslintComments.xml'), 'should create a checkstyle report.');
+
+    // check if the file names in the reports are absolute
+    var checkstyleFile = grunt.file.read('tmp/csslintComments.xml');
     var path = checkstyleFile.substring(checkstyleFile.indexOf('file name="') + 'file name="'.length, checkstyleFile.indexOf('invalid.css') + 'invalid.css'.length);
 
     test.ok(grunt.file.exists(path), 'should reference the right file.');


### PR DESCRIPTION
This pull request enables `grunt-contrib-csslint` to parse `.csslintrc` files with comments, in the same way that [`jshint` does](https://github.com/jshint/jshint/commit/5765c1bb9bce050311b3db3a470c97a523ecb2cd) for `.jshintrc`.