### PR TITLE
Show line /char numbers with lint issues

### DIFF
--- a/tasks/csslint.js
+++ b/tasks/csslint.js
@@ -73,7 +73,7 @@ module.exports = function(grunt) {
 
         result.messages.forEach(function(message) {
           var offenderMessage;
-          if (_.isUndefined(message.line)) {
+          if (!_.isUndefined(message.line)) {
             offenderMessage =
               chalk.yellow('L' + message.line) +
               chalk.red(':') +


### PR DESCRIPTION
We are checking the wrong condition so line/column numbers were never shown.

I considering switching to  `_.isNumber`, but decided to just try the most minimal fix possible..

Steps to reproduce:
- Use grunt-contrib-csslint on a css file with line errors

Expected results:
- The line number is reported:

```
[L15:C5]
>> ERROR: Duplicate property 'color' found. Duplicate properties must appear one after the other. (duplicate-properties) Browsers: All
```

Actual results:

```
[GENERAL]
>> ERROR: Duplicate property 'color' found. Duplicate properties must appear one after the other. (duplicate-properties) Browsers: All
```
